### PR TITLE
fix: prevent NPE and stack trace disclosure on registration endpoint

### DIFF
--- a/src/main/java/org/owasp/webgoat/container/users/RegistrationController.java
+++ b/src/main/java/org/owasp/webgoat/container/users/RegistrationController.java
@@ -40,7 +40,9 @@ public class RegistrationController {
       HttpServletRequest request,
       HttpServletResponse response)
       throws ServletException {
-    userValidator.validate(userForm, bindingResult);
+    if (!bindingResult.hasErrors()) {
+      userValidator.validate(userForm, bindingResult);
+    }
 
     if (bindingResult.hasErrors()) {
       return "registration";

--- a/src/main/java/org/owasp/webgoat/container/users/UserValidator.java
+++ b/src/main/java/org/owasp/webgoat/container/users/UserValidator.java
@@ -28,7 +28,8 @@ public class UserValidator implements Validator {
       errors.rejectValue("username", "username.duplicate");
     }
 
-    if (!userForm.getMatchingPassword().equals(userForm.getPassword())) {
+    if (userForm.getMatchingPassword() == null
+        || !userForm.getMatchingPassword().equals(userForm.getPassword())) {
       errors.rejectValue("matchingPassword", "password.diff");
     }
   }

--- a/src/main/resources/application-webgoat.properties
+++ b/src/main/resources/application-webgoat.properties
@@ -1,4 +1,4 @@
-server.error.include-stacktrace=always
+server.error.include-stacktrace=never
 server.error.path=/error.html
 server.servlet.context-path=${WEBGOAT_CONTEXT:/WebGoat}
 server.servlet.session.persistent=false


### PR DESCRIPTION
Add null-check in UserValidator before dereferencing matchingPassword, skip custom validation when bean validation already failed, and disable stack trace inclusion in error responses.

https://claude.ai/code/session_01Tf7vsacMAv6LSwxesfxQXJ

Thank you for submitting a pull request to the WebGoat!
